### PR TITLE
Artifice support for kernel 5.18.7-arch1-1

### DIFF
--- a/src/dm_afs.c
+++ b/src/dm_afs.c
@@ -7,6 +7,7 @@
 #include <dm_afs_io.h>
 #include <dm_afs_modules.h>
 #include <linux/delay.h>
+#include <linux/vmalloc.h>
 #include "lib/cauchy_rs.h"
 #include "lib/sha3.h"
 
@@ -249,7 +250,9 @@ __clone_bio(struct bio *bio_src, uint8_t **allocated_page, bool end_bio_src)
         return bio_src;
     }
 
-    bio_ret = bio_alloc(GFP_NOIO, 1);
+    ////bio_ret = bio_alloc(GFP_NOIO, 1);
+    bio_ret = bio_alloc(bio_src->bi_bdev,1,bio_src->bi_opf,GFP_NOIO);
+    
     afs_assert(!IS_ERR(bio_ret), alloc_err, "could not allocate bio [%ld]", PTR_ERR(bio_ret));
 
     page = kmalloc(AFS_BLOCK_SIZE, GFP_KERNEL);
@@ -275,7 +278,7 @@ __clone_bio(struct bio *bio_src, uint8_t **allocated_page, bool end_bio_src)
     }
 
     bio_add_page(bio_ret, virt_to_page(page), req_size, sector_offset * AFS_SECTOR_SIZE);
-    bio_ret->bi_opf = bio_src->bi_opf;
+    ////bio_ret->bi_opf = bio_src->bi_opf;
     bio_ret->bi_iter.bi_sector = bio_src->bi_iter.bi_sector;
     bio_ret->bi_iter.bi_size = req_size;
     bio_ret->bi_iter.bi_idx = 0;

--- a/src/dm_afs_engine.c
+++ b/src/dm_afs_engine.c
@@ -280,7 +280,8 @@ read_pages(struct afs_map_request *req, bool used_vmalloc, uint32_t num_pages) {
     for(i = 0; i < num_pages; i++) {
 	struct page *page_structure;
 
-        read_bios[i] = bio_alloc(GFP_NOIO, 1);
+	////read_bios[i] = bio_alloc(GFP_NOIO, 1);
+        read_bios[i] = bio_alloc(req->bdev, 1, REQ_OP_READ, GFP_NOIO);
         afs_action(!IS_ERR(read_bios[i]), ret = PTR_ERR(read_bios[i]), done, "could not allocate bio [%d]", ret);
         // Make sure page is aligned.
         afs_action(!((uint64_t)req->carrier_blocks[i] & (AFS_BLOCK_SIZE - 1)), ret = -EINVAL, done, "page is not aligned [%d]", ret);
@@ -289,8 +290,8 @@ read_pages(struct afs_map_request *req, bool used_vmalloc, uint32_t num_pages) {
         page_structure = (used_vmalloc) ? vmalloc_to_page(req->carrier_blocks[i]) : virt_to_page(req->carrier_blocks[i]);
         sector_num = (req->block_nums[i] * AFS_SECTORS_PER_BLOCK) + req->fs->data_start_off;
 
-        read_bios[i]->bi_opf |= REQ_OP_READ;
-        bio_set_dev(read_bios[i], req->bdev);
+        ////read_bios[i]->bi_opf |= REQ_OP_READ;
+        ////bio_set_dev(read_bios[i], req->bdev);
         read_bios[i]->bi_iter.bi_sector = sector_num;
         bio_add_page(read_bios[i], page_structure, AFS_BLOCK_SIZE, page_offset);
         read_bios[i]->bi_private = req;
@@ -317,7 +318,8 @@ write_pages(struct afs_map_request *req, bool used_vmalloc, uint32_t num_pages) 
     for(i = 0; i < num_pages; i++) {
         struct page *page_structure;
 
-        write_bios[i] = bio_alloc(GFP_NOIO, 1);
+        ////write_bios[i] = bio_alloc(GFP_NOIO, 1);
+        write_bios[i] = bio_alloc(req->bdev, 1, REQ_OP_WRITE, GFP_NOIO);
         afs_action(!IS_ERR(write_bios[i]), ret = PTR_ERR(write_bios[i]), done, "could not allocate bio [%d]", ret);
 
         // Make sure page is aligned.
@@ -327,8 +329,8 @@ write_pages(struct afs_map_request *req, bool used_vmalloc, uint32_t num_pages) 
         page_structure = (used_vmalloc) ? vmalloc_to_page(req->carrier_blocks[i]) : virt_to_page(req->carrier_blocks[i]);
         sector_num = (req->block_nums[i] * AFS_SECTORS_PER_BLOCK) + req->fs->data_start_off;
 
-        write_bios[i]->bi_opf |= REQ_OP_WRITE;
-        bio_set_dev(write_bios[i], req->bdev);
+        ////write_bios[i]->bi_opf |= REQ_OP_WRITE;
+        ////bio_set_dev(write_bios[i], req->bdev);
         write_bios[i]->bi_iter.bi_sector = sector_num;
         bio_add_page(write_bios[i], page_structure, AFS_BLOCK_SIZE, page_offset);
         write_bios[i]->bi_private = req;

--- a/src/dm_afs_io.c
+++ b/src/dm_afs_io.c
@@ -23,24 +23,26 @@ afs_blkdev_io(struct afs_io *request)
     const int page_offset = 0;
     int ret;
     struct bio *bio = NULL;
-
-    bio = bio_alloc(GFP_NOIO, 1);
-    afs_action(!IS_ERR(bio), ret = PTR_ERR(bio), alloc_err, "could not allocate bio [%d]", ret);
+    enum afs_io_type bi_opf;
 
     switch (request->type) {
     case IO_READ:
-        bio->bi_opf |= REQ_OP_READ;
+        bi_opf |= REQ_OP_READ;
         break;
 
     case IO_WRITE:
-        bio->bi_opf |= REQ_OP_WRITE;
+        bi_opf |= REQ_OP_WRITE;
         break;
 
     default:
         afs_action(0, ret = -EINVAL, invalid_type, "invalid IO type [%d]", request->type);
     }
 
-    bio_set_dev(bio, request->bdev);
+    ////bio = bio_alloc(GFP_NOIO, 1);	
+    bio = bio_alloc(request->bdev, 1 , bi_opf ,GFP_NOIO);
+    afs_action(!IS_ERR(bio), ret = PTR_ERR(bio), alloc_err, "could not allocate bio [%d]", ret);
+
+    ////bio_set_dev(bio, request->bdev);
     bio->bi_iter.bi_sector = request->io_sector;
     bio_add_page(bio, request->io_page, request->io_size, page_offset);
 

--- a/src/dm_afs_metadata.c
+++ b/src/dm_afs_metadata.c
@@ -9,6 +9,7 @@
 #include <linux/crypto.h>
 #include <linux/errno.h>
 #include <linux/random.h>
+#include <linux/vmalloc.h>
 
 /**
  * Binary search for use in finding a superblock

--- a/src/lib/bit_vector.c
+++ b/src/lib/bit_vector.c
@@ -5,6 +5,7 @@
  */
 #include <dm_afs.h>
 #include <lib/bit_vector.h>
+#include <linux/vmalloc.h>
 
 /**
  * Create and initialize a bit vector with its default values

--- a/src/modules/dm_afs_ext4.c
+++ b/src/modules/dm_afs_ext4.c
@@ -10,6 +10,7 @@
 #include <linux/slab.h>
 #include <linux/types.h>
 #include <linux/printk.h>
+#include <linux/vmalloc.h>
 
 /**
  * Constants relative to the data blocks

--- a/src/modules/dm_afs_fat32.c
+++ b/src/modules/dm_afs_fat32.c
@@ -10,6 +10,7 @@
 #include <linux/kernel.h>
 #include <linux/slab.h>
 #include <linux/types.h>
+#include <linux/vmalloc.h>
 
 // All the information about a FAT volume.
 struct fat_volume {

--- a/src/modules/dm_afs_ntfs.c
+++ b/src/modules/dm_afs_ntfs.c
@@ -6,8 +6,9 @@
 #include <dm_afs_modules.h>
 
 #include <linux/kern_levels.h>
+#include <linux/vmalloc.h>
 
-#include <stddef.h>
+#include "/usr/lib/modules/5.18.7-arch1-1/build/include/linux/stddef.h"
 
 #define ATTRS_DONE 0xFFFFFFFF
 

--- a/src/modules/dm_afs_shadow.c
+++ b/src/modules/dm_afs_shadow.c
@@ -4,6 +4,7 @@
  */
 #include <dm_afs.h>
 #include <dm_afs_modules.h>
+#include <linux/vmalloc.h>
 
 /**
  * Detect the presence of an existing Artifice file system


### PR DESCRIPTION
Hello, I was trying to compile Artifice for kernel 5.18.7-arch1-1 and run into some errors

Mainly
/home/user/build/Artifice/src/dm_afs.c:586:5: error: implicit declaration of function ‘vfree’; did you mean ‘kvfree’? [-Werror=implicit-function-declaration]
  586 |     vfree(context->afs_map);
      |     ^~~~~
      |     kvfree
/home/user/build/Artifice/src/dm_afs.c:230:15: error: too few arguments to function ‘bio_alloc’
  230 |     bio_ret = bio_alloc(GFP_NOIO, 1);

So I started debuging.

I added "#include <linux/vmalloc.h>" to
Artifice/src/dm_afs.c
Artifice/src/dm_afs_metadata.c
Artifice/src/lib/bit_vector.c
Artifice/src/modules/dm_afs_ext4.c
Artifice/src/modules/dm_afs_fat32.c
Artifice/src/modules/dm_afs_ntfs.c
Artifice/src/modules/dm_afs_shadow.c


Changed how bio_alloc was handled to support for the newer version with more arguments
I used this example to help : https://scm.linefinity.com/common/linux-stable/commit/07888c665b405b1cd3577ddebfeb74f4717a84c4?style=unified&whitespace=ignore-change

It then compile with some warnings. I joined files as html to preserve the colors.

I ran sudo insmod dm_afs.ko afs_debug_mode=1
and got "insmod: ERROR: could not insert module dm_afs.ko: Invalid parameters"

So I cheched dmesg, joined as html.
"BPF: Invalid name"

So I did modinfo dm_afs.ko
filename:       /home/user/build/old/Artifice/dm_afs.ko
license:        GPL
author:         Yash Gupta, Austen Barker
srcversion:     6AAFBB2A11CDE8BE789B4CB
depends:        dm-mod
retpoline:      Y
name:           dm_afs
vermagic:       5.18.7-arch1-1 SMP preempt mod_unload
parm:           afs_debug_mode:Set to 1 to enable debug mode {may affect performance} (int)

This is where I don't get what is the error exactly, so I decided will try to downgrade my kernel to lts.
I have never developed a kernel modules and my knowledge in c is basic.
I hope it will help you if you plan to support this kernel in the future.

Kind regards.